### PR TITLE
Save next middleware

### DIFF
--- a/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
+++ b/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
@@ -18,12 +18,12 @@ class FinishesHandlingMessageBeforeHandlingNext implements MessageBusMiddleware
      */
     public function handle(object $message, callable $next): void
     {
-        $this->queue[] = $message;
+        $this->queue[] = [$message, $next];
 
         if (!$this->isHandling) {
             $this->isHandling = true;
 
-            while ($message = array_shift($this->queue)) {
+            while ([$message, $next] = array_shift($this->queue)) {
                 try {
                     $next($message);
                 } catch (Throwable $exception) {


### PR DESCRIPTION
When the middleware is used on different buses, the queue does not respect the middleware of the original bus. Run the main bus middleware.